### PR TITLE
DCAC-50: Configure Jacoco and Sonar plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,15 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>${jib-maven-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar-maven-plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.pullrequest.base=main

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.pullrequest.base=main


### PR DESCRIPTION
### Sonar report warnings for PRs

* Noted that two warnings were issued for the PR Sonar reports:

```
Could not find ref 'master' in refs/heads, refs/remotes, refs/remotes/upstream or refs/remotes/origin. You may see unexpected issues and changes. Please make sure to fetch this ref before pull request analysis and refer to the documentation.
```

```
Unable to decorate the pull request. Please configure the pull request properties in the project administration.
```

![item-group-consumer sonar warnings](https://user-images.githubusercontent.com/54801196/217756223-713c1d63-faf9-4421-b47f-11119914edcf.png)

These appear to be down to the configuration of the project within Sonar. 

However, on comparing with an existing project with a `main` base branch in GitHub, `order-notification-sender`, I see the same warnings are issued, and as it is clearly providing a coverage figure as well as the other quality metrics, I conclude this is not a significant problem:

![order-notification-sender sonar warnings](https://user-images.githubusercontent.com/54801196/217756801-01941073-3215-4bef-ab21-caa297793826.png)

