### PR TITLE
DCAC-44: Stop ignoring -DskipTests and -DskipTests=true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M7</version>
                 <configuration>
-                    <skipTests>${skip.unit.tests}</skipTests>
+                    <skipTests>${skipTests}</skipTests>
                     <excludes>
                         <exclude>**/Runner.java</exclude>
                     </excludes>


### PR DESCRIPTION
* Stop ignoring `-DskipTests` and `-DskipTests=true`.
* As providing the argument `-DskipTests` or `-DskipTests=true` to the Maven command line is by far the most typical way to prevent test execution during certain build tasks (and is what our `Makefile` commands do), tweak the `maven-surefire-plugin` configuration to skip test execution when this flag is provided. 
* According to the [documentation](https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html), this should be the default behaviour, but we make it explicit here in contrast to another common tendency to set the `skipTests` value to `${skip.unit.tests}`, as we previously had.
* This should prevent the release from failing due to inappropriate execution of tests during the package build.