### PR TITLE
DCAC-152: Reconfigure for the shorter retry/error topic names we favour 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/itemgroupconsumer/Consumer.java
+++ b/src/main/java/uk/gov/companieshouse/itemgroupconsumer/Consumer.java
@@ -38,8 +38,7 @@ public class Consumer {
             attempts = "${consumer.max_attempts}",
             autoCreateTopics = "false",
             backoff = @Backoff(delayExpression = "${consumer.backoff_delay}"),
-            retryTopicSuffix = "-${consumer.group_id}-retry",
-            dltTopicSuffix = "-${consumer.group_id}-error",
+            dltTopicSuffix = "-error",
             dltStrategy = DltStrategy.FAIL_ON_ERROR,
             fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC,
             include = RetryableException.class

--- a/src/test/java/uk/gov/companieshouse/itemgroupconsumer/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/itemgroupconsumer/TestUtils.java
@@ -6,9 +6,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 public final class TestUtils {
 
     public static final String MAIN_TOPIC = "echo";
-    public static final String RETRY_TOPIC = "echo-echo-consumer-retry";
-    public static final String ERROR_TOPIC = "echo-echo-consumer-error";
-    public static final String INVALID_TOPIC = "echo-echo-consumer-invalid";
+    public static final String RETRY_TOPIC = "echo-retry";
+    public static final String ERROR_TOPIC = "echo-error";
+    public static final String INVALID_TOPIC = "echo-invalid";
 
     private TestUtils(){
     }

--- a/src/test/resources/application-test_main_nonretryable.properties
+++ b/src/test/resources/application-test_main_nonretryable.properties
@@ -9,7 +9,7 @@ consumer.max_attempts=4
 consumer.backoff_delay=100
 consumer.concurrency=1
 
-invalid_message_topic=echo-echo-consumer-invalid
+invalid_message_topic=echo-invalid
 
 logger.namespace=archetype-client
 

--- a/src/test/resources/application-test_main_positive.properties
+++ b/src/test/resources/application-test_main_positive.properties
@@ -9,7 +9,7 @@ consumer.max_attempts=4
 consumer.backoff_delay=100
 consumer.concurrency=1
 
-invalid_message_topic=echo-echo-consumer-invalid
+invalid_message_topic=echo-invalid
 
 logger.namespace=archetype-client
 

--- a/src/test/resources/application-test_main_retryable.properties
+++ b/src/test/resources/application-test_main_retryable.properties
@@ -9,7 +9,7 @@ consumer.max_attempts=4
 consumer.backoff_delay=100
 consumer.concurrency=1
 
-invalid_message_topic=echo-echo-consumer-invalid
+invalid_message_topic=echo-invalid
 
 logger.namespace=archetype-client
 

--- a/src/test/resources/item-group-ordered-in-tilt.properties
+++ b/src/test/resources/item-group-ordered-in-tilt.properties
@@ -4,7 +4,7 @@ consumer.group_id=item-group-consumer
 consumer.max_attempts=4
 consumer.backoff_delay=100
 consumer.concurrency=1
-invalid_message_topic=item-group-ordered-invalid
+invalid_message_topic=item-invalid
 
 logger.namespace=item-group-consumer
 steps: 1


### PR DESCRIPTION
* Change the config so that the retry/error topic names are `item-group-ordered-retry` and `item-group-ordered-error`, not `item-group-ordered-item-group-consumer-retry` and `item-group-ordered-item-group-consumer-error`.