### PR TITLE
use latest dependency-check setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,7 @@ artifact_name       := item-group-consumer
 version             := "unversioned"
 
 dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-
-# dependency_check_suppressions_repo_branch
-# The branch of the dependency-check-suppressions repository to use
-# as the source of the suppressions file.
-# This should point to "main" branch when being used for release,
-# but can point to a different branch for experimentation/development.
-dependency_check_suppressions_repo_branch:=feature/suppressions-for-company-accounts-api
-
+dependency_check_suppressions_repo_branch:=main
 dependency_check_minimum_cvss := 4
 dependency_check_assembly_analyzer_enabled := false
 dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
@@ -88,7 +81,7 @@ dependency-check:
 	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
 	if [  -f "$${suppressions_path}" ]; then \
 		cp -av "$${suppressions_path}" $(suppressions_file); \
-		mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
 	else \
 		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
 		exit 1; \
@@ -96,3 +89,4 @@ dependency-check:
 
 .PHONY: security-check
 security-check: dependency-check
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.9</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <version>2.1.11</version>
+        <relativePath/>
     </parent>
 
     <artifactId>item-group-consumer</artifactId>


### PR DESCRIPTION
1a7a5ae Update parent pom to 2.1.11, remove comment
Remove misleading comment on relativePath
relativePath prevents Maven from searching locally for the parent pom,
forcing it to go to the standard Maven repositories.

8870ccb Repoint Makefile at dep-check-suppressions/main
The 'dependency-check' target uses a variable
  dependency_check_suppressions_repo_branch
 which previously pointed to a different branch:
  feature/suppressions-for-company-accounts-api
 ... but that branch has been merged into main and so this variable
 should now point to main.
Tidy Makefile for dependency-check consistency
Remove extraneous comments.
Make line spacing, ordering, format for dependency-check sections
 identical across Makefiles.
Add json to dependency check report formats.

Jira [CC-1701](https://companieshouse.atlassian.net/browse/CC-1701)

[CC-1701]: https://companieshouse.atlassian.net/browse/CC-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ